### PR TITLE
List players by day and filter those without matches

### DIFF
--- a/api/src/messageHandling/MembershipHandler.js
+++ b/api/src/messageHandling/MembershipHandler.js
@@ -58,9 +58,11 @@ export default class MembershipHandler {
         matches = matches.filter(match => match.time > moment().subtract(numberDays, 'Days'))
       }
       league.runLeague(matches)
-      const listItems = league.leaderboard.map(p => p.getLeaderboardString()).join('</li><li>')
+      const listItems = league.leaderboard.filter(p => p.played > 0).map(p => p.getLeaderboardString()).join('</li><li>')
       const list = `<ol><li>${listItems}</li></ol>`
-      return notification.gray.html(`Table football leaderboard, sorted by skill level${leagueDays}: ${list}`)
+      const notPlayed = league.leaderboard.filter(p => p.played === 0).map(p => p.getLeaderboardString(false)).join('</li><li>')
+      const notPlayedList = notPlayed ? `</br>The following players have not played a game: <ol><li>${notPlayed}</li></ol>` : ''
+      return notification.gray.html(`Table football leaderboard, sorted by skill level${leagueDays}: ${list}${notPlayedList}`)
     } else {
       return notification.yellow.text(`There is no foosball league running in this room!`)
     }

--- a/api/src/player.js
+++ b/api/src/player.js
@@ -15,6 +15,10 @@ export default class Player extends TSPlayer {
     this.flawlessDefeats = 0
   }
 
+  get played () {
+    return this.won + this.lost
+  }
+
   get rating () {
     return this._rating
   }
@@ -55,8 +59,11 @@ export default class Player extends TSPlayer {
     }
   }
 
-  getLeaderboardString () {
-    return `${antiXSS(this.getId())} (${this.getRatingString()})${this.flawlessVictories ? ' ' + '🔥'.repeat(this.flawlessVictories) : ''}${this.flawlessDefeats ? ' ' + '💩'.repeat(this.flawlessDefeats) : ''}`
+  getLeaderboardString (includeRating = true) {
+    if (includeRating) {
+      return `${antiXSS(this.getId())} (${this.getRatingString()})${this.flawlessVictories ? ' ' + '🔥'.repeat(this.flawlessVictories) : ''}${this.flawlessDefeats ? ' ' + '💩'.repeat(this.flawlessDefeats) : ''}`
+    }
+    return `${antiXSS(this.getId())}`
   }
 
   getPostMatchString () {


### PR DESCRIPTION
This change allows you to add a day number to the end of the list commands and it will show you the league standing based on that period of time only. It will also list all players that have not completed any games at the bottom of the league table.